### PR TITLE
Serverless AC sync via lightweight curl_cffi CF bridge

### DIFF
--- a/cf-bridge/Dockerfile
+++ b/cf-bridge/Dockerfile
@@ -1,0 +1,15 @@
+# Lightweight Codeforces read-bridge — NO headless browser.
+# curl_cffi ships a bundled libcurl-impersonate, so the image stays tiny
+# (~150MB vs the old scrapling/Playwright image at ~1.5GB).
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app.py .
+
+EXPOSE 8787
+
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8787", "--workers", "2"]

--- a/cf-bridge/README.md
+++ b/cf-bridge/README.md
@@ -1,0 +1,94 @@
+# ICPC HUE — Lightweight Codeforces Bridge (read-only)
+
+Replaces the old heavy `scrapling-bridge` (FastAPI + Scrapling + Playwright,
+~1.5 GB, a real headless browser) for the **one** thing the serverless verify
+flow needs after the Vercel migration: **reading a user's submissions inside a
+PRIVATE Codeforces group, using the user's own session cookies** (supplied by
+the unchanged "Verdict Helper" browser extension).
+
+## Why a separate tiny service / function?
+
+Codeforces puts **group / contest** pages behind a Cloudflare *managed
+challenge* (`cf-mitigated: challenge`). This was verified empirically against a
+real private group (`group/MWSDmqGsZm/contest/219158`) with a real logged-in
+user's cookies:
+
+| How we ask Codeforces | Result |
+| --- | --- |
+| Node `fetch` (the Vercel runtime) + cookies | **403** — Cloudflare "Just a moment" |
+| `curl` + cookies | **403** |
+| Official API `contest.status`, **signed** with API key | `FAILED` — "Contest not found" (private groups are invisible to the API) |
+| Public API `user.status` | private-group submissions are **absent** |
+| Plain `curl` **with** a fresh `cf_clearance` (same IP) | **403** — clearance is bound to the browser TLS fingerprint |
+| Real headless browser + cookies | 200 ✅ (but needs ~1 GB + a browser, can't run on Vercel) |
+| **`curl_cffi` (Chrome TLS impersonation) + cookies** | **200** ✅ |
+
+The managed challenge here is a **TLS / HTTP-2 fingerprint** gate, not a JS gate.
+`curl_cffi` impersonates Chrome's fingerprint, so with the user's session
+cookies it passes — **no browser, no JS engine**. That makes this deployable as
+a normal serverless function. `curl_cffi` statically bundles
+`libcurl-impersonate`, so it runs on Lambda/Vercel with only standard system
+libs.
+
+> **Important:** `cf_clearance` MUST be stripped before the request. It is bound
+> to the originating browser's TLS fingerprint; reusing it from another client
+> triggers a 403. The plain session cookies (`JSESSIONID`, `39ce7`, `X-User`,
+> `X-User-Sha1`, …) are what authenticate the user. The bridge strips
+> `cf_clearance` (and auth/analytics cookies) automatically.
+
+## API
+
+`POST /submissions`
+
+```json
+{
+  "contestId": "219158",
+  "problemIndex": "F",            // optional; filters server-side
+  "cookies": "JSESSIONID=...; 39ce7=...; X-User=...",
+  "urlType": "group",             // contest | group | gym
+  "groupId": "MWSDmqGsZm",        // required when urlType=group
+  "count": 200
+}
+```
+
+```json
+{
+  "success": true,
+  "submissions": [
+    {
+      "id": 350360837,
+      "author": "BusinessDuck1",
+      "problemIndex": "F",
+      "problemName": "Digits Summation",
+      "verdict": "Accepted",
+      "timeConsumedMillis": 61,
+      "memoryConsumedBytes": 0,
+      "language": "C++20 (GCC 13-64)",
+      "creationTimeSeconds": 1780000000
+    }
+  ],
+  "error": null
+}
+```
+
+`GET /health` → `{ "status": "ok", "engine": "curl_cffi", "impersonate": "chrome120" }`
+
+## Deploy
+
+**As its own Vercel project (recommended — keeps the Python runtime separate):**
+1. Point a new Vercel project at the `cf-bridge/` directory.
+2. Vercel auto-detects FastAPI from `requirements.txt`/`pyproject.toml` and serves `app`.
+3. Set `SCRAPLING_BRIDGE_URL` in the Next.js project to the deployed bridge URL
+   (e.g. `https://cf-bridge.vercel.app`). The Next.js routes already read that env var.
+
+**As a container (Fly.io / Render / Railway / any Docker host):**
+```bash
+docker build -t cf-bridge ./cf-bridge
+docker run -p 8787:8787 cf-bridge
+```
+
+**Locally:**
+```bash
+pip install -r requirements.txt
+uvicorn app:app --port 8787
+```

--- a/cf-bridge/app.py
+++ b/cf-bridge/app.py
@@ -1,0 +1,231 @@
+"""
+ICPC HUE — Lightweight Codeforces Bridge (read-only)
+=====================================================
+
+Replaces the heavy Playwright "scrapling-bridge" for the ONE thing the
+serverless verify flow needs: reading a user's submissions in a PRIVATE
+Codeforces group, using the user's OWN session cookies (handed over by the
+unchanged "Verdict Helper" browser extension).
+
+Why this exists
+---------------
+Codeforces protects group/contest pages with a Cloudflare *managed challenge*
+(`cf-mitigated: challenge`). A plain server-side `fetch`/`curl`/Node-undici
+request is answered with HTTP 403 "Just a moment...". The official CF API
+(`contest.status`) cannot see private groups at all ("Contest not found"),
+even when signed with an API key, and `user.status` omits private-group subs.
+
+Empirically (tested against a real private group + real session cookies):
+  - Node fetch + cookies .......... 403 (Cloudflare challenge)
+  - curl + cookies ................ 403
+  - signed contest.status ......... FAILED "Contest not found"
+  - public user.status ............ private-group subs absent
+  - headless browser + cookies .... 200 (works, but needs ~1GB + a browser)
+  - curl_cffi (Chrome TLS impersonation) + cookies .... 200  ✅
+
+curl_cffi passes the challenge because Cloudflare's managed challenge here is a
+TLS/HTTP2 *fingerprint* gate, not a JS gate — so a fingerprint-impersonating
+HTTP client gets through with the user's session cookies. No JS engine /
+browser required, which makes this deployable as a tiny serverless function.
+
+IMPORTANT: the `cf_clearance` cookie must be STRIPPED before the request.
+It is bound to the originating browser's TLS fingerprint; sending it from a
+different client triggers a 403. Session cookies alone (JSESSIONID, 39ce7,
+X-User, X-User-Sha1, ...) are what authenticate the user.
+"""
+
+import re
+import html
+import time
+import logging
+from typing import Optional, List, Dict
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, Field
+from curl_cffi import requests as cffi_requests
+
+logger = logging.getLogger("cf-bridge")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+app = FastAPI(title="ICPC HUE CF Bridge", version="1.0.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Cookies that must NOT be forwarded to Codeforces:
+#  - cf_clearance: TLS-fingerprint-bound, breaks the request if reused elsewhere
+#  - analytics / app auth cookies: irrelevant + privacy
+_DROP_COOKIE_PREFIXES = ("sb-", "supabase", "_ga", "_gid", "_gat", "cf_clearance")
+_DROP_COOKIE_NAMES = {"authtoken", "cf_clearance"}
+
+# Chrome impersonation profile used for the TLS/HTTP2 fingerprint.
+_IMPERSONATE = "chrome120"
+
+# Codeforces verdict cell text -> normalized verdict
+_ACCEPTED_TOKENS = ("accepted", "ok")
+
+
+class SubmissionsRequest(BaseModel):
+    contestId: str
+    problemIndex: Optional[str] = None
+    cookies: str = Field(..., description="Raw Cookie header string from the extension")
+    urlType: str = "contest"  # contest | group | gym
+    groupId: Optional[str] = None
+    count: int = 200
+
+
+class Submission(BaseModel):
+    id: int
+    author: str
+    problemIndex: Optional[str] = None
+    problemName: Optional[str] = None
+    verdict: str
+    timeConsumedMillis: int = 0
+    memoryConsumedBytes: int = 0
+    language: str = ""
+    creationTimeSeconds: int = 0
+
+
+class SubmissionsResponse(BaseModel):
+    success: bool
+    submissions: List[Submission] = []
+    error: Optional[str] = None
+
+
+def _clean_cookie_header(raw: str) -> str:
+    """Drop cf_clearance / auth / analytics cookies, keep CF session cookies."""
+    out = []
+    for item in raw.split(";"):
+        item = item.strip()
+        if "=" not in item:
+            continue
+        name = item.split("=", 1)[0].strip()
+        low = name.lower()
+        if low in _DROP_COOKIE_NAMES:
+            continue
+        if any(low.startswith(p) for p in _DROP_COOKIE_PREFIXES):
+            continue
+        out.append(item)
+    return "; ".join(out)
+
+
+def _build_status_url(contest_id: str, url_type: str, group_id: Optional[str]) -> str:
+    """Build the per-user submissions page URL (the '/my' status table)."""
+    if url_type == "gym":
+        return f"https://codeforces.com/gym/{contest_id}/my"
+    if url_type == "group" and group_id:
+        return f"https://codeforces.com/group/{group_id}/contest/{contest_id}/my"
+    return f"https://codeforces.com/contest/{contest_id}/my"
+
+
+def _parse_ms(text: str) -> int:
+    m = re.search(r"(\d+)", text or "")
+    return int(m.group(1)) if m else 0
+
+
+def _parse_kb_to_bytes(text: str) -> int:
+    m = re.search(r"(\d+)", text or "")
+    return (int(m.group(1)) * 1024) if m else 0
+
+
+def _strip_tags(s: str) -> str:
+    return html.unescape(re.sub(r"\s+", " ", re.sub(r"<[^>]+>", " ", s))).strip()
+
+
+def _parse_status_table(html_text: str) -> List[Dict]:
+    """
+    Parse the Codeforces status datatable.
+    Columns (group /my view): [id, when, who, problem, lang, verdict, time, memory]
+    """
+    rows: List[Dict] = []
+    now = int(time.time())
+    for sid, body in re.findall(
+        r'<tr[^>]*data-submission-id="(\d+)"[^>]*>(.*?)</tr>', html_text, re.S
+    ):
+        cells = [_strip_tags(c) for c in re.findall(r"<td[^>]*>(.*?)</td>", body, re.S)]
+        if len(cells) < 6:
+            continue
+        # Defensive index mapping (group view has 8 cells)
+        problem_cell = cells[3] if len(cells) > 3 else ""
+        lang_cell = cells[4] if len(cells) > 4 else ""
+        verdict_cell = cells[5] if len(cells) > 5 else ""
+        time_cell = cells[6] if len(cells) > 6 else ""
+        mem_cell = cells[7] if len(cells) > 7 else ""
+
+        # problem cell looks like "F - Digits Summation"
+        pidx, pname = None, None
+        pm = re.match(r"^([A-Za-z][0-9]?)\s*-\s*(.*)$", problem_cell)
+        if pm:
+            pidx = pm.group(1).upper()
+            pname = pm.group(2).strip()
+
+        rows.append({
+            "id": int(sid),
+            "author": cells[2].strip() if len(cells) > 2 else "",
+            "problemIndex": pidx,
+            "problemName": pname,
+            "verdict": verdict_cell.strip(),
+            "timeConsumedMillis": _parse_ms(time_cell),
+            "memoryConsumedBytes": _parse_kb_to_bytes(mem_cell),
+            "language": lang_cell.strip(),
+            "creationTimeSeconds": now,
+        })
+    return rows
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok", "engine": "curl_cffi", "impersonate": _IMPERSONATE}
+
+
+@app.post("/submissions", response_model=SubmissionsResponse)
+async def get_submissions(req: SubmissionsRequest):
+    cookie_header = _clean_cookie_header(req.cookies)
+    if not cookie_header:
+        return SubmissionsResponse(success=False, error="NO_VALID_COOKIES")
+
+    url = _build_status_url(req.contestId, req.urlType, req.groupId)
+    if req.problemIndex:
+        url += f"?problemIndex={req.problemIndex.upper()}"
+
+    try:
+        resp = cffi_requests.get(
+            url,
+            headers={
+                "Cookie": cookie_header,
+                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+                "Accept-Language": "en-US,en;q=0.9",
+            },
+            impersonate=_IMPERSONATE,
+            timeout=30,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.exception("curl_cffi request failed")
+        return SubmissionsResponse(success=False, error=f"REQUEST_FAILED: {e}")
+
+    if resp.status_code != 200:
+        if "Just a moment" in resp.text:
+            return SubmissionsResponse(success=False, error="CLOUDFLARE_CHALLENGE")
+        return SubmissionsResponse(success=False, error=f"HTTP_{resp.status_code}")
+
+    if "status-frame-datatable" not in resp.text:
+        # Logged-out cookies -> CF redirects to a login/enter page without the table
+        if "/enter" in resp.text or "Login into Codeforces" in resp.text:
+            return SubmissionsResponse(success=False, error="NOT_LOGGED_IN")
+        return SubmissionsResponse(success=False, error="NO_SUBMISSIONS_TABLE")
+
+    parsed = _parse_status_table(resp.text)
+
+    if req.problemIndex:
+        want = req.problemIndex.upper()
+        parsed = [p for p in parsed if (p.get("problemIndex") or "").upper() == want]
+
+    return SubmissionsResponse(
+        success=True,
+        submissions=[Submission(**p) for p in parsed],
+    )

--- a/cf-bridge/pyproject.toml
+++ b/cf-bridge/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "icpchue-cf-bridge"
+version = "1.0.0"
+description = "Lightweight read-only Codeforces bridge (curl_cffi TLS impersonation). Reads a user's submissions in private CF groups using their own session cookies, bypassing the Cloudflare managed-challenge that blocks plain server-side fetch."
+requires-python = ">=3.12"
+dependencies = [
+    "fastapi>=0.115.0",
+    "curl_cffi>=0.7.1",
+    "pydantic>=2.10.0",
+]
+
+# Vercel loads `app` from app.py automatically; this is here for clarity / other hosts.
+[tool.vercel]
+entrypoint = "app:app"

--- a/cf-bridge/requirements.txt
+++ b/cf-bridge/requirements.txt
@@ -1,0 +1,4 @@
+fastapi>=0.115.0
+uvicorn>=0.34.0
+curl_cffi>=0.7.1
+pydantic>=2.10.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -292,6 +292,8 @@ services:
 
   # ===========================================
   # SCRAPLING BRIDGE (CF Submission Proxy)
+  # Heavy (Playwright headless browser) — only needed for the
+  # code-SUBMIT path (CSRF + Turnstile). Cannot run on Vercel.
   # ===========================================
   scrapling-bridge:
     build:
@@ -313,6 +315,35 @@ services:
       timeout: 10s
       retries: 3
       start_period: 15s
+
+  # ===========================================
+  # CF BRIDGE (read-only submission reader)
+  # Lightweight (curl_cffi TLS impersonation, NO browser, ~150MB).
+  # Reads a user's submissions in PRIVATE CF groups using their own
+  # session cookies — the part the serverless "Check & Sync my AC"
+  # button depends on. Deployable as a Vercel Python function too.
+  # Point the app's SCRAPLING_BRIDGE_URL / CF_BRIDGE_URL at this.
+  # ===========================================
+  cf-bridge:
+    build:
+      context: ./cf-bridge
+      dockerfile: Dockerfile
+    container_name: icpchue-cf-bridge
+    networks:
+      - icpchue-network
+    restart: always
+    logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://127.0.0.1:8787/health')\" || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
 
 # ===========================================
 # NETWORKS

--- a/next-app/.env.example
+++ b/next-app/.env.example
@@ -22,3 +22,14 @@ CF_API_KEY=your_codeforces_api_key
 CF_API_SECRET=your_codeforces_api_secret
 CF_CLIENT_SECRET=your_codeforces_client_secret
 JUDGE0_AUTH_TOKEN=your_judge0_token
+
+# Codeforces Bridge (reads a user's submissions in PRIVATE CF groups using their
+# own session cookies via curl_cffi TLS impersonation — bypasses the Cloudflare
+# managed-challenge that blocks plain serverless fetch). Powers the
+# "Check & Sync my AC" button. Deploy the ./cf-bridge service and point here.
+#   - Local docker-compose:  http://cf-bridge:8787
+#   - Standalone host:       https://your-cf-bridge.example.com
+CF_BRIDGE_URL=http://cf-bridge:8787
+# Legacy alias (still read as a fallback if CF_BRIDGE_URL is unset)
+SCRAPLING_BRIDGE_URL=http://cf-bridge:8787
+

--- a/next-app/app/api/submissions/verify/route.ts
+++ b/next-app/app/api/submissions/verify/route.ts
@@ -36,48 +36,114 @@ export async function POST(req: NextRequest) {
         const targetContestId = Number(contestId);
         let match = null;
 
-        // 1. If cookies are provided by the Chrome extension, perform authenticated fetches to support private contests/groups
+        // 1. If cookies are provided by the Chrome extension, query the user's
+        //    submissions via the CF Bridge. The bridge uses curl_cffi (Chrome TLS
+        //    impersonation) + the user's own session cookies to read the PRIVATE
+        //    group/contest status page — which a plain serverless fetch cannot do
+        //    (Cloudflare managed-challenge) and which the official API cannot see.
         if (cookies) {
-            console.log(`[Verify Route] Using user cookies for authenticated Codeforces query (Contest: ${targetContestId}, Problem: ${problemIndex})...`);
-            
-            // Try contest.status first (needed for private group contests)
-            const cfUrl = `https://codeforces.com/api/contest.status?contestId=${targetContestId}&from=1&count=200`;
+            console.log(`[Verify Route] Querying user submissions via CF Bridge (Contest: ${targetContestId}, Problem: ${problemIndex}, urlType: ${urlType})...`);
+
+            const BRIDGE_URL = process.env.CF_BRIDGE_URL || process.env.SCRAPLING_BRIDGE_URL || 'http://cf-bridge:8787';
+            const bridgeBody = JSON.stringify({
+                contestId: String(targetContestId),
+                problemIndex: problemIndex.toUpperCase(),
+                cookies,
+                urlType: urlType || 'contest',
+                groupId: groupId || null
+            });
+
+            let bridgeRes;
             try {
-                const cfRes = await fetch(cfUrl, {
-                    headers: {
-                        'Cookie': cookies,
-                        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-                        'Accept': 'application/json'
-                    }
+                bridgeRes = await fetch(`${BRIDGE_URL}/submissions`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: bridgeBody
                 });
-                
-                if (cfRes.ok) {
-                    const cfData = await cfRes.json();
-                    if (cfData.status === 'OK' && Array.isArray(cfData.result)) {
-                        const rawMatch = cfData.result.find((sub: any) => {
-                            const isProblemMatch = sub.problem?.index?.toUpperCase() === problemIndex.toUpperCase();
-                            const isAccepted = sub.verdict === 'OK' || sub.verdict?.toUpperCase() === 'ACCEPTED';
-                            const isUserMatch = 
-                                sub.author?.members?.some((m: any) => m.handle?.toLowerCase() === trimmedHandle.toLowerCase()) ||
-                                (sub.author?.handle && sub.author.handle.toLowerCase() === trimmedHandle.toLowerCase());
-                            return isProblemMatch && isAccepted && isUserMatch;
-                        });
-                        
-                        if (rawMatch) {
-                            console.log(`[Verify Route] Match found on contest.status! Submission: ${rawMatch.id}`);
-                            match = {
-                                id: Number(rawMatch.id),
-                                contestId: targetContestId,
-                                timeConsumedMillis: Number(rawMatch.timeConsumedMillis) || 0,
-                                memoryConsumedBytes: Number(rawMatch.memoryConsumedBytes) || 0,
-                                passedTestCount: Number(rawMatch.passedTestCount) || 15,
-                                programmingLanguage: rawMatch.programmingLanguage || language || 'C++'
-                            };
+            } catch (err: any) {
+                console.warn(`[Verify Route] Failed to connect to CF Bridge at ${BRIDGE_URL} (${err.message}). Trying local fallback (127.0.0.1:8787)...`);
+                try {
+                    bridgeRes = await fetch(`http://127.0.0.1:8787/submissions`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: bridgeBody
+                    });
+                } catch (localErr: any) {
+                    console.error('[Verify Route] Local CF Bridge fallback failed:', localErr.message);
+                }
+            }
+
+            if (bridgeRes && bridgeRes.ok) {
+                const bridgeData = await bridgeRes.json();
+                if (bridgeData.success && Array.isArray(bridgeData.submissions)) {
+                    // Find the matched Accepted submission. The bridge already
+                    // filters by problemIndex when provided, but we re-check
+                    // problemIndex + handle defensively.
+                    const rawMatch = bridgeData.submissions.find((sub: any) => {
+                        const isAccepted = sub.verdict?.toUpperCase() === 'ACCEPTED' || sub.verdict === 'OK';
+                        const isUserMatch = sub.author?.toLowerCase() === trimmedHandle.toLowerCase();
+                        const isProblemMatch = !sub.problemIndex ||
+                            sub.problemIndex.toUpperCase() === problemIndex.toUpperCase();
+                        return isAccepted && isUserMatch && isProblemMatch;
+                    });
+
+                    if (rawMatch) {
+                        console.log(`[Verify Route] Match found via CF Bridge! Submission: ${rawMatch.id}`);
+                        match = {
+                            id: Number(rawMatch.id),
+                            contestId: targetContestId,
+                            timeConsumedMillis: Number(rawMatch.timeConsumedMillis) || 0,
+                            memoryConsumedBytes: Number(rawMatch.memoryConsumedBytes) || 0,
+                            passedTestCount: 15,
+                            programmingLanguage: rawMatch.language || language || 'C++'
+                        };
+                    }
+                } else if (!bridgeData.success) {
+                    console.warn(`[Verify Route] CF Bridge returned error: ${bridgeData.error}`);
+                }
+            }
+
+            // Try contest.status as fallback
+            if (!match) {
+                console.log(`[Verify Route] Match not found via Scrapling Bridge. Falling back to contest.status (Contest: ${targetContestId})...`);
+                const cfUrl = `https://codeforces.com/api/contest.status?contestId=${targetContestId}&from=1&count=200`;
+                try {
+                    const cfRes = await fetch(cfUrl, {
+                        headers: {
+                            'Cookie': cookies,
+                            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+                            'Accept': 'application/json'
+                        }
+                    });
+                    
+                    if (cfRes.ok) {
+                        const cfData = await cfRes.json();
+                        if (cfData.status === 'OK' && Array.isArray(cfData.result)) {
+                            const rawMatch = cfData.result.find((sub: any) => {
+                                const isProblemMatch = sub.problem?.index?.toUpperCase() === problemIndex.toUpperCase();
+                                const isAccepted = sub.verdict === 'OK' || sub.verdict?.toUpperCase() === 'ACCEPTED';
+                                const isUserMatch = 
+                                    sub.author?.members?.some((m: any) => m.handle?.toLowerCase() === trimmedHandle.toLowerCase()) ||
+                                    (sub.author?.handle && sub.author.handle.toLowerCase() === trimmedHandle.toLowerCase());
+                                return isProblemMatch && isAccepted && isUserMatch;
+                            });
+                            
+                            if (rawMatch) {
+                                console.log(`[Verify Route] Match found on contest.status! Submission: ${rawMatch.id}`);
+                                match = {
+                                    id: Number(rawMatch.id),
+                                    contestId: targetContestId,
+                                    timeConsumedMillis: Number(rawMatch.timeConsumedMillis) || 0,
+                                    memoryConsumedBytes: Number(rawMatch.memoryConsumedBytes) || 0,
+                                    passedTestCount: Number(rawMatch.passedTestCount) || 15,
+                                    programmingLanguage: rawMatch.programmingLanguage || language || 'C++'
+                                };
+                            }
                         }
                     }
+                } catch (err: any) {
+                    console.error('[Verify Route] Cookie-auth contest.status fetch failed:', err);
                 }
-            } catch (err: any) {
-                console.error('[Verify Route] Cookie-auth contest.status fetch failed:', err);
             }
             
             // Try user.status with cookies as fallback

--- a/next-app/components/mirror/testrunner/CFStatusTab.tsx
+++ b/next-app/components/mirror/testrunner/CFStatusTab.tsx
@@ -19,6 +19,12 @@ interface CFStatusTabProps {
 export default function CFStatusTab({ cfStatus, contestId, problemId }: CFStatusTabProps) {
     const [isExtensionInstalled, setIsExtensionInstalled] = useState(true);
     const [handleInput, setHandleInput] = useState('');
+    // The handle was auto-resolved from the extension's active CF session,
+    // so the user doesn't have to type it (true one-click sync).
+    const [handleAutoResolved, setHandleAutoResolved] = useState(false);
+    // Lets the user reveal the manual handle field if auto-resolution failed
+    // or they want to override it.
+    const [showHandleField, setShowHandleField] = useState(false);
 
     useEffect(() => {
         try {
@@ -40,51 +46,90 @@ export default function CFStatusTab({ cfStatus, contestId, problemId }: CFStatus
         return () => clearTimeout(timer);
     }, []);
 
-    if (!cfStatus || cfStatus.status === 'idle') {
-        if (!isExtensionInstalled) {
-            return (
-                <div className="flex flex-col items-center justify-center h-full text-[#666] gap-4 p-4 text-center">
-                    <div className="w-16 h-16 rounded-full bg-red-500/10 text-red-400 flex items-center justify-center border border-red-500/20">
-                        <AlertTriangle size={28} />
-                    </div>
-                    <div>
-                        <p className="text-base font-bold text-white mb-1">Extension Required</p>
-                        <p className="text-sm text-[#888] mb-4">
-                            You need the ICPC HUE Helper extension to submit code to Codeforces directly from this page.
-                        </p>
-                    </div>
-                    <a
-                        href="https://chromewebstore.google.com/detail/verdict-helper/jeiffogppnpnefphgpglagmgbcnifnhj"
-                        target="_blank"
-                        className="flex items-center gap-2 px-4 py-2 bg-[#E8C15A] hover:bg-[#F0D06A] text-black font-semibold rounded-lg transition-colors text-sm"
-                    >
-                        Download Extension
-                        <ExternalLink size={14} />
-                    </a>
-                </div>
-            );
-        }
+    // Ask the (unchanged) Verdict Helper extension for the handle of the
+    // currently logged-in Codeforces session. This makes the sync one-click:
+    // the user is already logged into CF (that's how they submitted), so we
+    // can resolve their handle without asking them to type it.
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+        if (!document.getElementById('verdict-extension-installed')) return;
 
+        let done = false;
+        const handler = (event: MessageEvent) => {
+            if (event.source !== window) return;
+            if (event.data?.type !== 'VERDICT_HANDLE_RESPONSE') return;
+            done = true;
+            window.removeEventListener('message', handler);
+            const resolved = event.data.handle;
+            if (resolved && typeof resolved === 'string') {
+                setHandleInput(resolved);
+                setHandleAutoResolved(true);
+                try { localStorage.setItem('verdict-cf-handle', resolved); } catch {}
+            }
+        };
+        window.addEventListener('message', handler);
+        window.postMessage({ type: 'VERDICT_GET_HANDLE' }, '*');
+
+        const timeout = setTimeout(() => {
+            if (!done) window.removeEventListener('message', handler);
+        }, 4000);
+        return () => {
+            window.removeEventListener('message', handler);
+            clearTimeout(timeout);
+        };
+    }, []);
+
+    const isVerifyPending = cfStatus?.substatus === 'verify-pending';
+    // Show the one-click sync panel both when idle (extension present) and when
+    // a submit flow put us into "verify-pending". This makes the CF tab itself a
+    // button: open the problem, solve on CF, come back and sync — no Submit needed.
+    const showSyncPanel = isExtensionInstalled && (!cfStatus || cfStatus.status === 'idle' || isVerifyPending);
+
+    // ── Extension missing: prompt to install ──
+    if ((!cfStatus || cfStatus.status === 'idle') && !isExtensionInstalled) {
         return (
-            <div className="flex flex-col items-center justify-center h-full text-[#666] gap-3">
-                <div className="w-12 h-12 rounded-full bg-[#252526] flex items-center justify-center">
-                    <img
-                        src="/icons/codeforces-favicon.png"
-                        alt="CF"
-                        className="w-6 h-6 opacity-50"
-                    />
+            <div className="flex flex-col items-center justify-center h-full text-[#666] gap-4 p-4 text-center">
+                <div className="w-16 h-16 rounded-full bg-red-500/10 text-red-400 flex items-center justify-center border border-red-500/20">
+                    <AlertTriangle size={28} />
                 </div>
-                <p className="text-sm font-medium">Submit to Codeforces to see results</p>
-                <p className="text-xs text-[#555]">Use the Submit button above</p>
+                <div>
+                    <p className="text-base font-bold text-white mb-1">Extension Required</p>
+                    <p className="text-sm text-[#888] mb-4">
+                        You need the ICPC HUE Helper extension to sync your Codeforces submissions to this page.
+                    </p>
+                </div>
+                <a
+                    href="https://chromewebstore.google.com/detail/verdict-helper/jeiffogppnpnefphgpglagmgbcnifnhj"
+                    target="_blank"
+                    className="flex items-center gap-2 px-4 py-2 bg-[#E8C15A] hover:bg-[#F0D06A] text-black font-semibold rounded-lg transition-colors text-sm"
+                >
+                    Download Extension
+                    <ExternalLink size={14} />
+                </a>
             </div>
         );
     }
 
-    const isVerifyPending = cfStatus?.substatus === 'verify-pending';
+    if (showSyncPanel) {
+        const verifying = cfStatus?.progress === 50;
+        const hasError = cfStatus?.status === 'error';
+        // We can do a true one-click sync when the handle is already known
+        // (auto-resolved from the extension's CF session, or remembered).
+        const knownHandle = handleInput.trim();
+        const canOneClick = !!knownHandle;
+        const needsManualHandle = showHandleField || !canOneClick;
 
-    if (isVerifyPending) {
-        const verifying = cfStatus.progress === 50;
-        const hasError = cfStatus.status === 'error';
+        const runVerify = async () => {
+            const h = knownHandle;
+            if (!h) {
+                setShowHandleField(true);
+                return;
+            }
+            const verifyFn = (window as any).__verdict_verify_cf;
+            if (verifyFn) {
+                await verifyFn(h);
+            }
+        };
 
         return (
             <div className="h-full flex flex-col space-y-4 p-4 bg-[#252526]/30 rounded-xl border border-white/5 animate-fade-in text-left">
@@ -93,26 +138,28 @@ export default function CFStatusTab({ cfStatus, contestId, problemId }: CFStatus
                         <Send size={20} />
                     </div>
                     <div>
-                        <h3 className="font-bold text-sm text-white">Verify Codeforces Submission</h3>
-                        <p className="text-[10px] text-[#888]">Verify and apply your AC progress locally</p>
+                        <h3 className="font-bold text-sm text-white">Sync your Codeforces submission</h3>
+                        <p className="text-[10px] text-[#888]">Check your latest Codeforces submissions and apply your AC here</p>
                     </div>
                 </div>
 
                 <div className="text-[11px] text-[#b8b8b8] bg-white/5 p-3 rounded-lg leading-relaxed space-y-2">
-                    <p><strong>1. Submit Code:</strong> Make sure you have submitted your solution on Codeforces (opened in the other tab).</p>
-                    <p><strong>2. Check Result:</strong> Once you get <strong>Accepted (AC)</strong> on Codeforces, enter your handle below and click verify to sync your progress here!</p>
+                    <p><strong>1. Submit on Codeforces:</strong> Solve the problem and get <strong>Accepted (AC)</strong> on Codeforces.</p>
+                    <p><strong>2. Sync here:</strong> Click the button below — we&apos;ll check your latest submissions for this problem and mark it solved if an AC is found.</p>
                 </div>
 
-                {hasError && cfStatus.error && (
+                {hasError && cfStatus?.error && (
                     <div className="p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-xs text-red-400 flex items-start gap-2 leading-relaxed">
                         <AlertTriangle size={14} className="shrink-0 mt-0.5" />
                         <span>{cfStatus.error}</span>
                     </div>
                 )}
 
-                <div className="flex flex-col gap-1.5">
-                    <label className="text-[9px] font-bold text-[#888] uppercase tracking-wider">Codeforces Handle</label>
-                    <div className="flex gap-2">
+                {/* Manual handle field — only shown if we couldn't auto-resolve it
+                    from the extension, or the user chose to override it. */}
+                {needsManualHandle && (
+                    <div className="flex flex-col gap-1.5">
+                        <label className="text-[9px] font-bold text-[#888] uppercase tracking-wider">Codeforces Handle</label>
                         <input
                             type="text"
                             value={handleInput}
@@ -124,31 +171,44 @@ export default function CFStatusTab({ cfStatus, contestId, problemId }: CFStatus
                             }}
                             disabled={verifying}
                             placeholder="Enter your CF handle (e.g. tourist)"
-                            className="flex-1 bg-[#1a1a1a] border border-white/10 hover:border-white/20 focus:border-[#E8C15A]/50 rounded-lg px-3 py-2 text-xs text-white placeholder-[#555] focus:outline-none transition-colors"
+                            className="bg-[#1a1a1a] border border-white/10 hover:border-white/20 focus:border-[#E8C15A]/50 rounded-lg px-3 py-2 text-xs text-white placeholder-[#555] focus:outline-none transition-colors"
                         />
-                        <button
-                            onClick={async () => {
-                                if (!handleInput.trim()) return;
-                                const verifyFn = (window as any).__verdict_verify_cf;
-                                if (verifyFn) {
-                                    await verifyFn(handleInput.trim());
-                                }
-                            }}
-                            disabled={verifying || !handleInput.trim()}
-                            className="flex items-center gap-1.5 px-3 py-2 bg-[#E8C15A] hover:bg-[#F0D06A] disabled:bg-[#E8C15A]/20 disabled:text-[#666] text-black font-semibold rounded-lg transition-colors text-xs shrink-0 cursor-pointer"
-                        >
-                            {verifying ? (
-                                <>
-                                    <Loader2 size={12} className="animate-spin" /> Verifying...
-                                </>
-                            ) : (
-                                <>
-                                    <CheckCircle2 size={12} /> Apply Solution
-                                </>
-                            )}
-                        </button>
                     </div>
-                </div>
+                )}
+
+                <button
+                    onClick={runVerify}
+                    disabled={verifying || (needsManualHandle && !canOneClick)}
+                    className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-[#E8C15A] hover:bg-[#F0D06A] disabled:bg-[#E8C15A]/20 disabled:text-[#666] text-black font-semibold rounded-lg transition-colors text-sm cursor-pointer"
+                >
+                    {verifying ? (
+                        <>
+                            <Loader2 size={14} className="animate-spin" /> Checking your submissions...
+                        </>
+                    ) : (
+                        <>
+                            <CheckCircle2 size={14} /> Check &amp; Sync my AC
+                        </>
+                    )}
+                </button>
+
+                {/* Show the resolved handle + a way to change it */}
+                {canOneClick && (
+                    <div className="flex items-center justify-center gap-1.5 text-[10px] text-[#888]">
+                        <span>
+                            Checking as <span className="text-[#E8C15A] font-mono">{knownHandle}</span>
+                            {handleAutoResolved && ' (from your Codeforces session)'}
+                        </span>
+                        {!verifying && (
+                            <button
+                                onClick={() => setShowHandleField(true)}
+                                className="text-[#E8C15A] hover:underline cursor-pointer"
+                            >
+                                change
+                            </button>
+                        )}
+                    </div>
+                )}
 
                 {contestId && problemId && (
                     <div className="pt-2 flex items-center justify-between border-t border-white/5">
@@ -165,6 +225,10 @@ export default function CFStatusTab({ cfStatus, contestId, problemId }: CFStatus
             </div>
         );
     }
+
+    // After the early returns above, cfStatus is guaranteed non-null (idle/null
+    // states are handled by the sync panel). This guard narrows the type for TS.
+    if (!cfStatus) return null;
 
     const statusColor = getCFStatusColor(cfStatus);
     const statusBg = getCFStatusBg(cfStatus);


### PR DESCRIPTION
## Summary
Adds a one-click **Check & Sync my AC** button to the Codeforces tab that reads the user's submissions in PRIVATE Codeforces groups using their own session cookies (supplied by the unchanged Verdict Helper extension), then marks the problem solved in icpchue.

## Why
After migrating off the SSH host to Vercel serverless, the heavy Playwright `scrapling-bridge` can no longer run. Investigated empirically against a real private group + real session cookies:

| Approach | Result |
|---|---|
| Node `fetch` / `curl` + cookies | 403 Cloudflare `cf-mitigated: challenge` |
| Official API `contest.status` (signed) | FAILED "Contest not found" (private groups invisible) |
| Public `user.status` | private-group subs absent |
| plain curl WITH `cf_clearance` | 403 (clearance is TLS-fingerprint-bound) |
| **curl_cffi (Chrome TLS impersonation) + cookies** | **200 ✅ reliable** |

The group protection is a TLS/HTTP2 fingerprint gate, not a JS gate — so a fingerprint-impersonating HTTP client passes with the user's cookies. No headless browser needed. `cf_clearance` must be stripped (it's fingerprint-bound).

## Changes
- **`cf-bridge/`** — new read-only FastAPI service (curl_cffi, ~150MB, no browser). `POST /submissions` strips cf_clearance/auth/analytics cookies, fetches the group `/my` status page, parses + filters by problemIndex. Deployable as a container or a Vercel Python function.
- **`verify/route.ts`** — point the bridge branch at `CF_BRIDGE_URL`, defensive problemIndex+handle matching. DB persistence unchanged.
- **`CFStatusTab.tsx`** — CF tab becomes a button; auto-resolves the handle from the extension's CF session for true one-click, manual fallback.
- **docker-compose + env examples** — add `cf-bridge` service and `CF_BRIDGE_URL`.

The browser extension was **not** modified.

## Tested
- End-to-end against private group `MWSDmqGsZm/219158`: problem F returns the real Accepted submission. cf_clearance stripping confirmed.
- `tsc --noEmit` passes clean.

## Note
The existing `isExtensionVerified` trust-path in verify lets a client claim an AC by submissionId without server re-validation. Recommend tightening it to always require a bridge-confirmed AC before granting leaderboard credit (follow-up).